### PR TITLE
Adding a web installer

### DIFF
--- a/app/Console/Commands/Install.php
+++ b/app/Console/Commands/Install.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+
+class Install extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'vmdash:install';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Setup vmDash and install all required dependencies.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $envExample = base_path('.env.example');
+        $env = base_path('.env');
+
+        $this->line('Creating the environment file...');
+        if (!file_exists($envExample))
+        {
+            $this->error('The environment file \'.env.example\' required for this installation does not exist.');
+        }
+        else
+        {
+            copy($envExample, $env);
+            $this->info('File created successfully.' . PHP_EOL);
+            $this->line('Configuring the encryption key...');
+            $this->call('key:generate');
+        }
+    }
+}

--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Validator;
+
+class InstallController extends Controller
+{
+    public function __construct() {
+        if (file_exists(base_path() . '/install.lock') && Route::getCurrentRoute()->getActionMethod() !== 'showLocked')
+            return redirect('install/locked')->send();
+    }
+
+    public function getRequirementsChecker()
+    {
+        return view('install.requirements', [
+            'requirements' => $this->checkRequirements('list'),
+            'status' => $this->checkRequirements()
+        ]);
+    }
+
+    public function postRequirementsChecker()
+    {
+        if ($this->checkRequirements())
+            return redirect()->route('install.getDatabase');
+        else
+            $this->getRequirementsChecker();
+    }
+
+    public function getDatabaseSetup()
+    {
+        return view('install.database');
+    }
+
+    public function postDatabaseSetup(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'host' => 'required',
+            'port' => 'required',
+            'database' => 'required',
+            'username' => 'required'
+        ]);
+
+        if ($validator->fails())
+        {
+            return redirect()->route('install.getDatabase')->withErrors($validator)->withInput(
+                $request->except('password')
+            );
+        }
+
+        $this->setEnv('DB_HOST', $request->input('host'));
+        $this->setEnv('DB_PORT', $request->input('port'));
+        $this->setEnv('DB_DATABASE', $request->input('database'));
+        $this->setEnv('DB_USERNAME', $request->input('username'));
+        $this->setEnv('DB_PASSWORD', $request->input('password'));
+
+        Artisan::call('cache:clear');
+
+        try
+        {
+            DB::connection()->getPdo();
+            Artisan::call('migrate', array('--force' => true));
+            
+            if ($this->checkMigrations())
+                return redirect()->route('install.getAdministrator');
+            else
+            {
+                $errors = [
+                    'Could not populate the database with the required tables.',
+                    'Error: ' . Artisan::output()
+                ];
+
+                return redirect()->route('install.getDatabase')->withErrors($errors)->withInput(
+                    $request->except('password')
+                );
+            }
+        }
+        catch (\Exception $e)
+        {
+            $errors = [
+                'Could not connect to the database. Please check your configuration.',
+                'Error: ' . $e->getMessage()
+            ];
+
+            return redirect()->route('install.getDatabase')->withErrors($errors)->withInput(
+                $request->except('password')
+            );
+        }
+    }
+
+    public function getCreateAdministrator()
+    {
+        return view('install.administrator');
+    }
+
+    public function postCreateAdministrator(Request $request)
+    {
+        $validator = Validator::make($request->all(), User::rules());
+
+        if ($validator->fails())
+        {
+            return redirect()->route('install.getAdministrator')->withErrors($validator)->withInput(
+                $request->except(['password', 'password_confirmation'])
+            );
+        }
+        
+        User::create([
+            'name' => $request->input('name'),
+            'email' => $request->input('email'),
+            'password' => $request->input('password'),
+            'role' => 10
+        ]);
+
+        return redirect()->route('install.getSuccess');
+    }
+
+    public function getSuccess() {
+        return view('install.success');
+    }
+
+    public function getLocked()
+    {
+        return view('install.locked');
+    }
+
+    private function checkRequirements($function = null)
+    {
+        $requirements['php_version'] = [
+            'message' => 'PHP version is higher than 7.1.3.',
+            'status' => version_compare(PHP_VERSION, "7.1.3", ">=")
+        ];
+
+        $requirements['php_openssl'] = [
+            'message' => 'PHP OpenSSL Extension is installed and loaded.',
+            'status' => extension_loaded("openssl")
+        ];
+
+        $requirements['php_pdo'] = [
+            'message' => 'PHP PDO Extension is installed and loaded.',
+            'status' => defined('PDO::ATTR_DRIVER_NAME')
+        ];
+
+        $requirements['php_mbstring'] = [
+            'message' => 'PHP Mbstring Extension is installed and loaded.',
+            'status' => extension_loaded("mbstring")
+        ];
+
+        $requirements['php_tokenizer'] = [
+            'message' => 'PHP Tokenizer Extension is installed and loaded.',
+            'status' => extension_loaded("tokenizer")
+        ];
+
+        $requirements['php_xml'] = [
+            'message' => 'PHP XML Extension is installed and loaded.',
+            'status' => extension_loaded("xml")
+        ];
+
+        $requirements['php_ctype'] = [
+            'message' => 'PHP Ctype Extension is installed and loaded.',
+            'status' => extension_loaded("ctype")
+        ];
+
+        $requirements['php_json'] = [
+            'message' => 'PHP JSON Extension is installed and loaded.',
+            'status' => extension_loaded("json")
+        ];
+
+        $requirements['writable_storage'] = [
+            'message' => 'The storage directory \'/storage\' is writable.',
+            'status' => is_writable(storage_path())
+        ];
+
+        $requirements['writable_cache'] = [
+            'message' => 'The cache directory \'/bootstrap/cache\' is writable.',
+            'status' => is_writable(base_path('bootstrap/cache'))
+        ];
+
+        if ($function == 'list')
+            return $requirements;
+        else
+        {
+            // Get status (true/false) by filtering the array of requirements.
+            return empty(array_filter($requirements, function($requirement) {
+                // Remove all enabled requirements from the array.
+                return !$requirement['status'];
+            }));
+        }
+    }
+
+    private function checkMigrations() {
+        $dbQuery = DB::select('select migration from migrations');
+        $migrations = scandir(database_path('migrations'));
+
+        $dbMigrations = [];
+
+        foreach ($dbQuery as $row)
+        {
+            array_push($dbMigrations, $row->migration . '.php');
+        }
+
+        if (empty(array_diff($migrations, $dbMigrations)))
+            return true;
+        else
+            return false;
+    }
+
+    private function setEnv($key, $value) {
+        $env = base_path('.env');
+
+        return file_put_contents($env, preg_replace('/' . $key . '=(.*)' . PHP_EOL . '/', $key . '=' . $value . PHP_EOL, file_get_contents($env)));
+    }
+}

--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -12,7 +12,7 @@ use Validator;
 class InstallController extends Controller
 {
     public function __construct() {
-        if (file_exists(base_path() . '/install.lock') && Route::getCurrentRoute()->getActionMethod() !== 'showLocked')
+        if (file_exists(base_path('install.lock')) && Route::getCurrentRoute()->getActionMethod() !== 'getLocked')
             return redirect('install/locked')->send();
     }
 
@@ -115,11 +115,14 @@ class InstallController extends Controller
             'password' => $request->input('password'),
             'role' => 10
         ]);
-
+        
         return redirect()->route('install.getSuccess');
     }
 
     public function getSuccess() {
+        // Create new lock file after installation is completed.
+        touch(base_path('install.lock'));
+
         return view('install.success');
     }
 

--- a/resources/views/install/administrator.blade.php
+++ b/resources/views/install/administrator.blade.php
@@ -1,0 +1,43 @@
+@extends('install.layout')
+
+@section('title', 'Create Administrator')
+
+@section('content')
+    <p>Enter your new administrator account details below. This will be the first user and will be used to login to vmDash.</p>
+
+    @if ($errors->any())
+    <div id="errors" class="alert alert-danger" role="alert">
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+    @endif
+    
+    <form action="{{ route('install.postAdministrator') }}" method="post">
+        {{ csrf_field() }}
+    
+        <div class="form-group">
+            <label for="name">Name</label>
+            <input type="text" class="form-control" name="name" id="name" placeholder="John Smith">
+        </div>
+
+        <div class="form-group">
+            <label for="email">Email</label>
+            <input type="email" class="form-control" name="email" id="email" placeholder="jsmith@example.com" required>
+        </div>
+
+        <div class="form-group">
+            <label for="password">Password</label>
+            <input type="password" class="form-control" name="password" id="password" placeholder="••••••••" required>
+        </div>
+
+        <div class="form-group">
+            <label for="password_confirmation">Password Confirmation</label>
+            <input type="password" class="form-control" name="password_confirmation" id="password_confirmation" placeholder="••••••••" required>
+        </div>
+        
+        <button type="submit" class="btn btn-primary float-right"><i class="fas fa-user-plus"></i> Create Account</button>
+    </form>
+@endsection

--- a/resources/views/install/database.blade.php
+++ b/resources/views/install/database.blade.php
@@ -1,0 +1,62 @@
+@extends('install.layout')
+
+@section('title', 'Database Setup')
+
+@section('content')
+    <p>Enter your database connection details below. The installer will automatically setup the database tables for vmDash.</p>
+
+    @if ($errors->any())
+    <div id="errors" class="alert alert-danger" role="alert">
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+    @endif
+    
+    <h6 class="mb-3">Database Conenction Details</h6>
+    
+    <form action="{{ route('install.postDatabase') }}" method="post">
+        {{ csrf_field() }}
+    
+        <div class="form-group">
+            <label for="host">Host</label>
+            <input type="text" class="form-control" name="host" id="host" aria-describedby="hostHelp" placeholder='localhost' value="{{ old('host') }}" required>
+            <small id="hostHelp" class="form-text text-muted">This is <code>localhost</code> if the database is hosted on the same server. If this doesn't work, enter your MySQL server address.</small>
+        </div>
+
+        <div class="form-group">
+            <label for="port">Port</label>
+            <input type="text" class="form-control" name="port" id="port" aria-describedby="portHelp" placeholder='3306' value="{{ old('port') }}" required>
+            <small id="portHelp" class="form-text text-muted">This is usually <code>3306</code> for MySQL. If this doesn't work, get the port from your MySQL server.</small>
+        </div>
+
+        <div class="form-group">
+            <label for="database">Database</label>
+            <input type="text" class="form-control" name="database" id="database" aria-describedby="databaseHelp" placeholder="vmdash" value="{{ old('database') }}" required>
+            <small id="databaseHelp" class="form-text text-muted">Create a new database in your MySQL server and enter the database name above.</small>
+        </div>
+
+        <div class="form-group">
+            <label for="username">Username</label>
+            <input type="text" class="form-control" name="username" id="username" aria-describedby="usernameHelp" placeholder="root" value="{{ old('username') }}" required>
+            <small id="usernameHelp" class="form-text text-muted">The MySQL username of the user that has full priveleges to the database.</small>
+        </div>
+
+        <div class="form-group">
+            <label for="password">Password</label>
+
+            <div class="input-group">
+                <input type="password" class="form-control" name="password" id="password" aria-describedby="passwordHelp">
+                <div class="input-group-append" onclick="maskPassword()">
+                    <span class="input-group-text"><i id="passwordIcon" class="fas fa-eye"></i></span>
+                </div>
+            </div>
+
+            <small id="passwordHelp" class="form-text text-muted">The password of the MySQL user entered above.</small>
+        </div>
+        
+        <button type="submit" class="btn btn-primary float-right"><i class="fas fa-database"></i> Setup Database</button>
+    </form>
+@endsection

--- a/resources/views/install/layout.blade.php
+++ b/resources/views/install/layout.blade.php
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <title>{{ config('app.name', 'Laravel') }} Installer</title>
+
+    <style>
+        #requirements {
+            list-style-type: none;
+            padding-left: 20px;
+        }
+
+        #requirements li {
+            line-height: 40px;
+        }
+
+        #requirements li svg {
+            vertical-align: middle;
+            margin-right: 5px;
+        }
+
+        #requirements i {
+            margin-right: 5px;
+        }
+
+        #errors ul {
+            margin-bottom: 0px;
+        }
+
+        .card {
+            margin-bottom: 25px;
+        }
+    </style>
+
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.1/css/all.css" integrity="sha384-O8whS3fhG2OnA5Kas0Y9l3cfpmYjapjI0E4theH4iuMD+pLhbf6JI0jIMfYcK3yZ" crossorigin="anonymous">
+</head>
+<body class="bg-light">
+    <div class="container">
+        <div class="py-5 text-center">
+            <img class="d-block mx-auto mb-3" src="{{ asset('images/vmdash_logo.png') }}" width="72" alt="">
+            <h2>vmDash Installer</h2>
+        </div>
+
+        <div class="card">
+            <h5 id="installTitle" class="card-header">@yield('title')</h5>
+            <div id="installBody" class="card-body">
+                @yield('content')
+            </div>
+        </div>
+
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/js/bootstrap.min.js" integrity="sha384-o+RDsa0aLu++PJvFqy8fFScvbHFLtbvScb8AjopnFD+iEQ7wo/CG0xlczd+2O/em" crossorigin="anonymous"></script>
+        <script>
+            function maskPassword()
+            {
+                var passwordField = document.getElementById('password');
+                var passwordIcon = document.getElementById('passwordIcon');
+
+                if (passwordField.type == 'password')
+                {
+                    passwordField.type = 'text';
+                    passwordIcon.className = 'fas fa-eye-slash';
+                }
+                else
+                {
+                    passwordField.type = 'password';
+                    passwordIcon.className = 'fas fa-eye';
+                }
+            }
+        </script>
+</body>
+</html>

--- a/resources/views/install/locked.blade.php
+++ b/resources/views/install/locked.blade.php
@@ -1,0 +1,8 @@
+@extends('install.layout')
+
+@section('title', 'Installer Locked')
+
+@section('content')
+    <div class="alert alert-warning" role="alert">The installer is currently locked, please remove 'install.lock' file from the project directory to continue.</div>
+    <a href="../install" class="btn btn-primary float-right"><i class="fas fa-sync"></i> Re-run Installer</a>
+@endsection

--- a/resources/views/install/requirements.blade.php
+++ b/resources/views/install/requirements.blade.php
@@ -1,0 +1,32 @@
+@extends('install.layout')
+
+@section('title', 'Requirements Checker')
+
+@section('content')
+    <p>This process checks if your server and PHP configuration meets the requirements for running this vmDash version. It checks version of PHP, if appropriate PHP extensions have been loaded, and if PHP directives are set correctly.</p>
+    
+    @if ($status)
+        <div id="errors" class="alert alert-success" role="alert">Your server configuration fully match all requirements for this vmDash version.</div>
+    @else
+        <div id="errors" class="alert alert-danger" role="alert">Your server configuration does not fully match all requirements for this vmDash version.</div>
+    @endif
+
+    <h6 class="mb-3">Requirements</h6>
+    
+    <ul id="requirements">
+        @foreach ($requirements as $requirement => $info)
+            @if ($info['status'])
+                <li><i class="text-success far fa-check-circle"></i>  
+            @else
+                <li><i class="text-danger far fa-times-circle"></i>  
+            @endif
+
+            {{ $info['message'] }}</li>
+        @endforeach
+    </ul>
+    
+    <form action="{{ route('install.postRequirements') }}" method="post">
+        {{ csrf_field() }}
+        <button type="submit" class="btn btn-primary float-right"{{ !$status ? ' disabled' : '' }}>Continue <i class="fas fa-chevron-right"></i></button>
+    </form>
+@endsection

--- a/resources/views/install/success.blade.php
+++ b/resources/views/install/success.blade.php
@@ -1,0 +1,7 @@
+@extends('install.layout')
+
+@section('title', 'Installation Successful')
+
+@section('content')
+    <div class="alert alert-success" role="alert">vmDash has been successfully installed and configured. You can start adding servers by <a href="{{ url('/') }}" class="alert-link">logging in</a> with the your new credentials!</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,4 +44,17 @@ Route::get('/', function () {
     return view('auth.login');
 });
 
+Route::group(['prefix' => 'install'], function() {
+    Route::get('/', 'InstallController@index');
+});
 
+Route::group(['prefix' => 'install', 'as' => 'install.'], function () {
+    Route::get('/', 'InstallController@getRequirementsChecker')->name('getRequirements');
+    Route::post('/', 'InstallController@postRequirementsChecker')->name('postRequirements');
+    Route::get('/database', 'InstallController@getDatabaseSetup')->name('getDatabase');
+    Route::post('/database', 'InstallController@postDatabaseSetup')->name('postDatabase');
+    Route::get('/admin', 'InstallController@getCreateAdministrator')->name('getAdministrator');
+    Route::post('/admin', 'InstallController@postCreateAdministrator')->name('postAdministrator');
+    Route::get('/success', 'InstallController@getSuccess')->name('getSuccess');
+    Route::get('/locked', 'InstallController@getLocked')->name('getLocked');
+});


### PR DESCRIPTION
This pull request contains a few files for the web installer feature. Creating a web installer will make it easier for new users to install vmDash into their environments. The commits contains:

- Artisan command (vmdash:install) to create a new environment file from the example and generate the application encryption key.
- Controller (InstallController) that manages all the actions required by the web installer.
- Views for each step of the web installer.
- Routes required for the web installer to function (/install/*).
- A 'install.lock' file to lock the installation, once completed or after cloning the project.